### PR TITLE
Enquote -neopath

### DIFF
--- a/src/guide/install/index.md
+++ b/src/guide/install/index.md
@@ -74,7 +74,7 @@ location. Open up "Properties..." then launch options and set to your
 custom install path:
 
 ```
--neopath C:\PATH\TO\YOUR\NEOTOKYO\NeotokyoSource\
+-neopath "C:\PATH\TO\YOUR\NEOTOKYO\NeotokyoSource\"
 ```
 
 #### Linux


### PR DESCRIPTION
The `-neopath` argument must be encapsulated in double quotes if the path contains space characters. Update the example path to use this convention, to avoid users getting confused with paths like `-neopath D:\My Games\NeotokyoSource` not working.