### PR TITLE
Add Javascript to automatically fetch latest release from Github

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SITE_TITLE := Neotokyo; Rebuild
 SRC_DIR := src
 DST_DIR := _out
 SRCS := $(shell find $(SRC_DIR) -name '*.md' | grep -vxF "src/index.md")
-SRCS_CPY := $(SRC_DIR)/style.css $(SRC_DIR)/favicon.ico $(shell find $(SRC_DIR) -name '*.png')
+SRCS_CPY := $(SRC_DIR)/style.css $(SRC_DIR)/favicon.ico $(shell find $(SRC_DIR) -name '*.png') $(SRC_DIR)/releases.js
 
 BLOG_LIST_FILE := _metadata/blog_list
 BLOG_DATES := _metadata/blog_dates
@@ -29,7 +29,7 @@ $(DST_DIR)/%.html: $(SRC_DIR)/%.md $(SRC_DIR)/_header.html $(SRC_DIR)/_footer.ht
 	@mkdir -p $(dir $@)
 	@SSG_TITLE=$$(lowdown -X title $<); \
 		m4 -DSSG_TITLE="$$SSG_TITLE" $(SRC_DIR)/_header.html > $@.header.html.tmp
-	@lowdown -Thtml -o $@.tmp $< 
+	@lowdown -Thtml --html-no-skiphtml --html-no-escapehtml -o $@.tmp $< 
 	@cat $@.header.html.tmp $@.tmp $(SRC_DIR)/_footer.html > $@
 	@rm $@.tmp $@.header.html.tmp
 	@case $< in $(SRC_DIR)/blog/*) \
@@ -55,7 +55,7 @@ $(DST_DIR)/index.html: $(SRC_DIR)/blog/*/*.md $(SRC_DIR)/_header.html $(SRC_DIR)
 	@cat $(BLOG_LIST_FILE).tmp | sort -ur > $(BLOG_LIST_FILE)
 	@rm $(BLOG_LIST_FILE).tmp
 	@m4 -DSSG_TITLE="Home" $(SRC_DIR)/_header.html > $@.header.html.tmp
-	@lowdown -Thtml -o $@.tmp < $(SRC_DIR)/index.md
+	@lowdown -Thtml --html-no-skiphtml --html-no-escapehtml -o $@.tmp < $(SRC_DIR)/index.md
 	@echo "<ul>" >> $@.mid
 	@cat $(BLOG_LIST_FILE) | while read line; do \
 		entry_date=$$(echo "$$line" | cut -f1); \

--- a/src/guide/install/index.md
+++ b/src/guide/install/index.md
@@ -25,11 +25,18 @@ Install [Source SDK Base 2013 (MP) Multiplayer](steam://rungameid/243750) (AppID
 
 ## Downloading NT;RE
 
-For Pre-alpha v9.0, click on the following links to download the zip files:
+Click on the following links to download the zip files:
 
-* Windows and Linux: [neo-20241012-bc3a767-resources.zip](https://github.com/NeotokyoRebuild/neo/releases/download/v9.0-prealpha/neo-20241012-bc3a767-resources.zip)
-* Windows-only: [neo-20241012-bc3a767-libraries-Windows-Release.zip](https://github.com/NeotokyoRebuild/neo/releases/download/v9.0-prealpha/neo-20241012-bc3a767-libraries-Windows-Release.zip)
-* Linux-only: [neo-20241012-bc3a767-libraries-Linux-Release.zip](https://github.com/NeotokyoRebuild/neo/releases/download/v9.0-prealpha/neo-20241012-bc3a767-libraries-Linux-Release.zip)
+<div id="downloading-ntre-div">
+    <noscript>
+        <p>Sorry, Javascript is required to generate the download links.</p>
+        <p>
+            If you don't want to enable Javascript, see the download links manually from:
+            <a href="https://github.com/NeotokyoRebuild/neo/releases">https://github.com/NeotokyoRebuild/neo/releases</a>
+        </p>
+    </noscript>
+    <script type="text/javascript" src="/releases.js"></script>
+</div>
 
 For other versions, go to the [GitHub release](https://github.com/NeotokyoRebuild/neo/releases/) page and find the
 version you want and expand the "Assets" section. You only need to install a zip file that ends with

--- a/src/index.md
+++ b/src/index.md
@@ -3,10 +3,24 @@ title: Home
 # Neotokyo; Rebuild
 Neotokyo; Rebuild is a work in progress Source SDK 2013 mod of
 [NEOTOKYO](https://store.steampowered.com/app/244630/NEOTOKYO/).
-Builds are available for Windows and Linux on GitHub, the latest release is [Pre-Alpha v9.0](https://github.com/NeotokyoRebuild/neo/releases/tag/v9.0-prealpha).
+Builds available for Windows and Linux are hosted on GitHub.
 
 * [Install NT;RE (client)](/guide/install/)
 * [Git Repository on GitHub](https://github.com/NeotokyoRebuild/neo)
+
+
+## Downloading NT;RE
+
+<div id="downloading-ntre-div">
+    <noscript>
+        <p>Sorry, Javascript is required to generate the download links.</p>
+        <p>
+            If you don't want to enable Javascript, see the download links manually from:
+            <a href="https://github.com/NeotokyoRebuild/neo/releases">https://github.com/NeotokyoRebuild/neo/releases</a>
+        </p>
+    </noscript>
+    <script type="text/javascript" src="/releases.js"></script>
+</div>
 
 ## Blog
 [Atom feed](/atom.xml)

--- a/src/releases.js
+++ b/src/releases.js
@@ -1,0 +1,67 @@
+"use strict";
+
+function getDownloadLinks() {
+  const SCHEME = "https",
+    API = "api.github.com",
+    RES = "repos",
+    ORG = "NeotokyoRebuild",
+    REPO = "neo",
+    QUERY = "releases/latest";
+
+  const url = `${SCHEME}://${API}/${RES}/${ORG}/${REPO}/${QUERY}`;
+
+  fetch(url)
+    .catch((e) => console.error(e))
+    .then((res) => {
+      res
+        .json()
+        .catch((e) => console.error(e))
+        .then((j) => {
+          const tagName = j["tag_name"];
+          const published = new Date(j["published_at"]);
+
+          let assets = Array.from(j["assets"]).filter((a) => {
+            return [
+              "libraries-Linux-Release",
+              "libraries-Windows-Release",
+              "resources",
+            ].some((v) => a.name.includes(v));
+          });
+
+          const labels = [
+            "Linux-only binaries: ",
+            "Windows-only binaries: ",
+            "Windows and Linux resources: ",
+          ];
+          let i = 0;
+
+          let div = document.getElementById("downloading-ntre-div");
+          if (!div) {
+            console.error("div not found");
+            return;
+          }
+
+          let pInfo = document.createElement("p");
+          pInfo.appendChild(document.createTextNode("Current release: " + tagName));
+          pInfo.appendChild(document.createElement("br"));
+          pInfo.appendChild(document.createTextNode("Published on: " + published.toISOString().split('T')[0]));
+          div.appendChild(pInfo);
+
+          assets.forEach((asset) => {
+            console.log(asset);
+
+            div.appendChild(document.createTextNode(labels[i]));
+            i += 1;
+
+            let a = document.createElement("a");
+            a.appendChild(document.createTextNode(asset.name));
+            a.appendChild(document.createElement("br"));
+            a.href = asset.browser_download_url;
+
+            div.appendChild(a);
+          });
+        });
+    });
+}
+
+window.onload = getDownloadLinks;


### PR DESCRIPTION
* Adapted from rain's https://gist.github.com/Rainyan/322e811504ec11296538849299a0da29
* Applied to homepage and install guide
* Eventually, we'll want to hook from main repo to this to auto statically generate it. But this is good enough for now.