### PR TITLE
Troubleshooter for Linux glibc 2.41>= engine.so issue

### DIFF
--- a/src/_footer.html
+++ b/src/_footer.html
@@ -1,5 +1,7 @@
     <hr>
-    <p>Neotokyo; Rebuild - 2024</p>
+    <p>
+    Neotokyo; Rebuild - 2024-2025 | Neotokyo: Revamp - 2019-2024
+    </p>
   </body>
 </html>
 

--- a/src/guide/install/index.md
+++ b/src/guide/install/index.md
@@ -1,7 +1,7 @@
 title: Guide - Install NT;RE (Client)
 
 # Guide - Install NT;RE (Client)
-Last Updated: 2024-10-13
+Last Updated: 2025-02-13
 
 ## Operating System Requirement
 
@@ -99,3 +99,22 @@ then click "Run". This will popup everytime NT;RE is started through Steam.
 [Double check the contents](#installing-ntre) of your installation folder, you probably did not extract folders/files properly or are missing some all together. Make sure you have downloaded the necessary libraries and resource files from the "Assets" section of the latest release. Down below is an image of how your installation folder should look like:
 
 ![Picture of the installation folder](folderstructure.png)
+
+### Linux - engine.so: cannot enable executable stack as shared object requires: Invalid argument
+
+Since [glibc 2.41, Source SDK 2013's `engine.so` will fail to load](https://github.com/ValveSoftware/portal2/issues/451)
+causing the game to not start. To workaround this, go to the Source SDK 2013 Multiplayer's bin directory:
+
+```
+~/.steam/steam/steamapps/common/Source SDK Base 2013 Multiplayer/bin
+```
+
+Then make a backup of `engine.so` and use [execstack](https://linux.die.net/man/8/execstack) on it:
+
+```
+cp engine.so engine.so.bak
+execstack -c engine.so
+```
+
+NT;RE should be able to load up normally afterward.
+


### PR DESCRIPTION
See: https://github.com/ValveSoftware/portal2/issues/451

Fairly bleeding-edge distros like Arch already have glibc 2.41>= which behavior change has caused the Source SDK 2013 to fail to load by default, requiring a workaround for now.