### PR TITLE
Update game name stylisation & bump year

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SITE_HTTPS_URL := https://neotokyorebuild.github.io/
-SITE_TITLE := Neotokyo; Rebuild
+SITE_TITLE := NEOTOKYO;REBUILD
 
 SRC_DIR := src
 DST_DIR := _out

--- a/src/_footer.html
+++ b/src/_footer.html
@@ -1,6 +1,6 @@
     <hr>
     <p>
-    NEOTOKYO;REBUILD - 2024-2025 | Neotokyo: Revamp - 2019-2024
+    NEOTOKYO;REBUILD - 2024-2026 | Neotokyo: Revamp - 2019-2024
     </p>
   </body>
 </html>

--- a/src/_footer.html
+++ b/src/_footer.html
@@ -1,6 +1,6 @@
     <hr>
     <p>
-    Neotokyo; Rebuild - 2024-2025 | Neotokyo: Revamp - 2019-2024
+    NEOTOKYO;REBUILD - 2024-2025 | Neotokyo: Revamp - 2019-2024
     </p>
   </body>
 </html>

--- a/src/_header.html
+++ b/src/_header.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>SSG_TITLE | Neotokyo; Rebuild</title>
-    <link rel="alternate" href="/atom.xml" type="application/atom+xml" title="Neotokyo; Rebuild blog atom feed">
+    <title>SSG_TITLE | NEOTOKYO;REBUILD</title>
+    <link rel="alternate" href="/atom.xml" type="application/atom+xml" title="NEOTOKYO;REBUILD blog atom feed">
     <link rel="stylesheet" href="/style.css">
     <link rel="icon" href="/favicon.ico">
   </head>
@@ -12,7 +12,7 @@
     <header>
       <p>
         <span>
-          <b>Neotokyo; Rebuild</b>
+          <b>NEOTOKYO;REBUILD</b>
           - <a href="/">home</a>
           | <a href="/guide/install">install</a>
           | <a href="/atom.xml">atom</a>

--- a/src/index.md
+++ b/src/index.md
@@ -1,7 +1,7 @@
 title: Home
 
-# Neotokyo; Rebuild
-Neotokyo; Rebuild is a work in progress Source SDK 2013 mod of
+# NEOTOKYO;REBUILD
+NEOTOKYO;REBUILD is a work in progress Source SDK 2013 mod of
 [NEOTOKYO°](https://store.steampowered.com/app/244630/NEOTOKYO/).
 Builds available for Windows and Linux are hosted on GitHub.
 


### PR DESCRIPTION
* Stylise game name as `NEOTOKYO;REBUILD`, and shorthand as `NT;RE`.
* Bump year from 2025 -> 2026